### PR TITLE
fix: correct eudiw ri credential status code when missing proof

### DIFF
--- a/src/main/java/se/digg/eudiw/controllers/CredentialController.java
+++ b/src/main/java/se/digg/eudiw/controllers/CredentialController.java
@@ -77,7 +77,7 @@ public class CredentialController {
             if (authentication.getPrincipal() instanceof Jwt) {
 
                 // wallet proof in request from wallet
-                Optional<JWK> proofJwk = Optional.empty();
+                Optional<JWK> proofJwk = proofDecoder.decodeJwtProf(credential.getProof());
 
                 JwtProof jwtProof = credential.getProof();
 
@@ -169,7 +169,7 @@ public class CredentialController {
     }
 
     @ExceptionHandler({MethodArgumentNotValidException.class, TokenIssuingException.class})
-    public ResponseEntity<String> handleIllegalArgumentException(MethodArgumentNotValidException ex) {
+    public ResponseEntity<String> handleIllegalArgumentException(Exception ex) {
         logger.info("Cannot issue credential", ex);
         String wwwAuthenticate = "";
         Nonce dPoPNonce = new Nonce();


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed or added.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes #(issue)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
