### PR TITLE
ci: use reusable-ci v1

### DIFF
--- a/.github/workflows/openssfscorecard.yml
+++ b/.github/workflows/openssfscorecard.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2025 The wallet-issuer-poc Authors
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -9,11 +9,11 @@ on:
     branches:
       - main
   schedule:
-    # Weekly on Saturdays.
+    # Weekly on Wednesdays at 01:30 UTC
     - cron: "30 1 * * 3"
 
 permissions:
-  contents: read
+  contents: read  # Best Security practice. Jobs only get read as base, and then permissions are added as needed
 
 jobs:
   scorecard-analysis:
@@ -21,4 +21,4 @@ jobs:
       contents: read
       security-events: write
       id-token: write
-    uses: diggsweden/.github/.github/workflows/openssf-scorecard.yml@main
+    uses: diggsweden/.github/.github/workflows/security-openssf-scorecard.yml@feat/ci-refactor

--- a/.github/workflows/pullrequest-workflow.yml
+++ b/.github/workflows/pullrequest-workflow.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Digg - Agency for Digital Government
+# SPDX-FileCopyrightText: 2025 The wallet-issuer-poc Authors
 #
 # SPDX-License-Identifier: CC0-1.0
 
@@ -6,33 +6,32 @@
 name: Pull Request Workflow
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+      - develop
+      - 'release/**'
+      - 'feature/**'
 
 permissions:
-  contents: read
+  contents: read  # Best Security practice. Jobs only get read as base, and then permissions are added as needed
 
 jobs:
-  commitlint:
-    uses: diggsweden/.github/.github/workflows/commit-lint.yml@main
-  dependencyreviewlint:
-    uses: diggsweden/.github/.github/workflows/dependency-review.yml@main
-  #licenselint:
-  #  uses: diggsweden/.github/.github/workflows/license-lint.yml@main
-  misclint:
+  pr-checks:
+    uses: diggsweden/reusable-ci/.github/workflows/pullrequest-orchestrator.yml@v1
+    secrets: inherit  # Pass org-level secrets (for private package access if needed)
     permissions:
-      contents: read
-      security-events: write
-    uses: diggsweden/.github/.github/workflows/megalint.yml@main
+      contents: read         # Clone and read repository code
+      packages: read         # Download packages from GitHub Packages (for dependencies)
+      security-events: write # Upload security scan results to GitHub Security tab
+    with:
+      projectType: maven
+      linters.licenselint: false  # Skip license checking (POC/test project)
+  
   test:
+    needs: [pr-checks]
+    if: always()  # Run tests even if linting fails (get complete feedback)
     permissions:
-      contents: read
-      packages: read
-    if: always()
-    #needs: [licenselint, commitlint, dependencyreviewlint, misclint]
-    needs: [commitlint, dependencyreviewlint, misclint]
+      contents: read  # Access source code for testing
+      packages: read  # Fetch test dependencies from GitHub Packages
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/release-workflow-dev.yml
+++ b/.github/workflows/release-workflow-dev.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2025 The wallet-issuer-poc Authors
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Release Workflow Dev
+# 
+# This workflow triggers the dev release orchestrator for development and feature branches.
+# It creates dev-tagged artifacts and container images for testing.
+#
+# Triggers:
+# - Push to dev/* or feat/* branches  
+# - Manual workflow dispatch
+#
+# Created artifacts:
+# - Container images with dev tags
+# - See release summary for full details
+
+name: Release Workflow Dev
+
+on:
+  push:
+    branches:
+      - 'dev/**'
+      - 'feat/**'
+  workflow_dispatch:
+
+jobs:
+  dev-release:
+    permissions:
+      contents: write         # Read code and create version bump commits
+      packages: write         # Push dev images to ghcr.io
+    uses: diggsweden/reusable-ci/.github/workflows/release-dev-orchestrator.yml@v1
+    with:
+      projectType: maven
+    secrets: inherit

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -1,55 +1,49 @@
-# SPDX-FileCopyrightText: 2024 Digg - The Agency for Digital Government
+# SPDX-FileCopyrightText: 2025 The wallet-issuer-poc Authors
 #
 # SPDX-License-Identifier: CC0-1.0
-
 name: Release Workflow
 
 on:
   push:
     tags:
-      - "v[0-9]*.[0-9]*" # Forces at least vX.Y and then allows anything after
+      - "v[0-9]+.[0-9]+.[0-9]+"              # Stable: v1.0.0
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha*"       # Alpha: v1.0.0-alpha.1
+      - "v[0-9]+.[0-9]+.[0-9]+-beta*"        # Beta: v1.0.0-beta.1
+      - "v[0-9]+.[0-9]+.[0-9]+-rc*"          # RC: v1.0.0-rc.1
+      - "v[0-9]+.[0-9]+.[0-9]+-snapshot*"    # Snapshot: v1.0.0-snapshot
+      - "v[0-9]+.[0-9]+.[0-9]+-SNAPSHOT*"    # Snapshot: v1.0.0-SNAPSHOT
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false  # Queue releases, don't cancel partial releases
 
 permissions:
-  contents: read
+  contents: read  # Best Security practice. Jobs only get read as base, and then permissions are added as needed
 
 jobs:
   release:
     permissions:
-      contents: write
-      packages: write
-      id-token: write
-      actions: read   # Required for SLSA provenance v2
-      security-events: write
-      attestations: write  # Required for SBOM attestation
-    secrets: inherit
-    uses: diggsweden/.github/.github/workflows/release-orchestrator.yml@feat/ci-refactor
+      contents: write         # Create GitHub releases, push tags and commits
+      packages: write         # Publish JARs to GitHub Packages and images to ghcr.io
+      id-token: write        # Generate OIDC token for SLSA provenance attestation
+      actions: read          # Read workflow runs for SLSA provenance generation
+      security-events: write # Upload vulnerability scan results from container scanning
+      attestations: write    # Attach SBOM attestation to container images
+    secrets: inherit  # Use org-level GPG keys, Maven credentials if configured
+    uses: diggsweden/reusable-ci/.github/workflows/release-orchestrator.yml@v1
     with:
       # Project configuration
-      projectType: maven
-      releaseType: stable
+      projectType: maven  # Build system type (determines version file location)
       
-      # Version and changelog - same as before
-      skipVersionBump: false
-      changelogConfig: ".github-templates/gitcliff-templates/keepachangelog.toml"
+      # Artifact publisher configuration
+      artifactPublisher: maven-app-github  # Publishes JAR to GitHub Packages
       
-      # Maven publishing - preserving existing behavior
-      skipArtifactPublish: false
-      artifactRegistry: github
+      # Container builder configuration  
+      containerBuilder: containerimage-ghcr  # Build and push Docker image to ghcr.io
+      container.platforms: "linux/amd64,linux/arm64"  # Multi-arch support for Intel and ARM
       
-      # Container image - preserving all existing features
-      skipContainerPublish: false
-      containerRegistry: ghcr.io
-      containerPlatforms: "linux/amd64,linux/arm64"
-      containerEnableSLSA: true  # Preserving SLSA provenance
-      containerfile: Containerfile
+      # Changelog configuration
+      changelogCreator: git-cliff  # Generate changelog from conventional commits
       
-      # GitHub Release - using JReleaser to preserve existing setup
-      skipGitHubRelease: false
-      useJReleaser: true  # Preserving JReleaser functionality
-      jreleaserConfig: jreleaser.yml
-      generateSBOM: true  # Already configured in jreleaser.yml
-      signArtifacts: true  # Already using GPG signing
-      attachArtifacts: "target/*.jar"
-      
-      # Java configuration
-      javaVersion: "21"
+      # Release publisher configuration
+      releasePublisher: github-cli  # Creates GitHub release with changelog and artifacts

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,6 +1,5 @@
 # Basic project metadata
 project:
-  name: eudiw-wallet-issuer-poc
   description: Test and PoC only
   license: EUPL-1.2 
   copyright: 2025 Digg - The Agency for Digital Government
@@ -19,14 +18,13 @@ release:
     overwrite: true     # Allows updating existing releases
     draft: false        # Creates as final release, not draft
     sign: true          # Signs release assets
-    branch: main
     changelog:
       external: ReleasenotesTmp
 
 checksum:
+  name: 'checksums.sha256'
   algorithms:
     - SHA-256
-    - SHA-512
 
 
 # GPG signing configuration
@@ -34,19 +32,27 @@ signing:
   active: ALWAYS
   armored: true
 
-# SBOM generation
+# SBOM generation disabled - generated manually from pom.xml before JReleaser runs
 catalog:
   sbom:
     syft:
-      active: ALWAYS
-      formats: 
-        - CYCLONEDX_JSON  
-        - SPDX_JSON
-      pack:
-        enabled: true
+      active: NEVER
 
-# Syft need to know what to sign
+# Distribution artifacts to include in release
 distributions:
-  library:
+  app:
+    type: SINGLE_JAR
     artifacts:
-      - path: target/{{projectName}}-{{projectVersion}}.jar
+      - path: target/{{projectName}}.jar
+
+# Additional files to upload to release (library JAR + SBOMs)
+files:
+  artifacts:
+    # Library JAR (versioned, without embedded dependencies)
+    - path: target/{{projectName}}-{{projectVersion}}.jar
+      extraProperties:
+        skipSigning: false
+    # SBOM ZIP containing all 3 layers (consistent with GitHub CLI path)
+    - path: '{{projectName}}-{{projectVersion}}-sboms.zip'
+      extraProperties:
+        skipSigning: false

--- a/pom.xml
+++ b/pom.xml
@@ -472,17 +472,6 @@
   </build>
 
   <repositories>
-    <repository>
-        <id>snapshots</id>
-        <url>https://registry.digg.se/repository/maven-snapshots/</url>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-        <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>always</updatePolicy>
-        </snapshots>
-    </repository>
   <repository>
     <name>Central Portal Snapshots</name>
     <id>central-portal-snapshots</id>


### PR DESCRIPTION
Replaces the obsolete CI-pipelines with reusable-ci (v1)

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
